### PR TITLE
Fix broken links

### DIFF
--- a/src/site/pages/faq.html
+++ b/src/site/pages/faq.html
@@ -673,15 +673,6 @@ org.slf4j.impl.StaticLoggerBinder.SINGLETON from class org.slf4j.LoggerFactory
       is not exactly exciting nor endearing.) 
       </p>
 
-      <p>The <a
-      href="http://velocity.apache.org/engine/devel/developer-guide.html#Configuring_Logging">logging
-      strategy adopted by the Velocity project</a> is a good example
-      of the "custom logging abstraction" anti-pattern. By adopting an
-      independent logging abstraction strategy, Velocity developers
-      have made life harder for themselves, but more importantly, they
-      made life harder for their users.
-      </p>
-
       <p>Some projects try to detect the presence of SLF4J on the
       class path and switch to it if present. While this approach
       seems transparent enough, it will result in erroneous location
@@ -1712,7 +1703,7 @@ try {
       </p>          
       
       <p>The Apache Commons wiki contains an <a
-      href="http://wiki.apache.org/commons/Logging/StaticLog">informative
+      href="https://cwiki.apache.org/confluence/x/GB_GBg">informative
       article</a> covering the same question.</p>
       
       <p><b>Logger serialization</b></p>


### PR DESCRIPTION
The first link isn't broken per se; rather, the Velocity team have apparently changed their ways.
`Since version 2.0, Velocity has switched to the SLF4J logging facade.`