### PR TITLE
Fix typo in fluent logging API examples

### DIFF
--- a/src/site/pages/manual.html
+++ b/src/site/pages/manual.html
@@ -252,7 +252,7 @@ SLF4J: See https://www.slf4j.org/codes.html#StaticLoggerBinder for further detai
         int oldT = 16;
 
         // using classical API
-        logger.debug("oldT={} newT={} Temperature changed.", newT, oldT);
+        logger.debug("oldT={} newT={} Temperature changed.", oldT, newT);
 
         // using fluent API
         logger.atDebug().setMessge("Temperature changed.").<b>addKeyValue("oldT", oldT)</b>.addKeyValue("newT", newT).log();          


### PR DESCRIPTION
It's a migration of https://github.com/qos-ch/slf4j/pull/209