### PR TITLE
added "Other backends" with tinylog from https://en.wikipedia.org/wiki/SLF4J

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # slf4j-site
 
-This repository contains the contents of [https://www.slf4j.org](https://www.slf4j.org) site
+This repository contains the contents of [https://www.slf4j.org](https://www.slf4j.org) site.
 
 # Build instructions
 
@@ -8,6 +8,9 @@ The site is copied more than built.
 
 The command for "building" the site contents is:
 
-`mvn install`
+    mvn install
 
 This copies html files from `src/site/pages/` folder to `target/site` folder, performing variable replacements along the way.
+
+The local version of the website can then 'be navigated at
+[target/site/index.html](target/site/index.html)

--- a/src/site/pages/templates/left.js
+++ b/src/site/pages/templates/left.js
@@ -24,6 +24,8 @@ document.write('    <a href="api/org/slf4j/jul/JDK14LoggerAdapter.html">JUL</a>'
 document.write('    <a href="api/org/slf4j/log4j12/Log4jLoggerAdapter.html">Log4j</a>');
 document.write('    <a href="api/org/slf4j/reload4j/Reload4jLoggerAdapter.html">reload4j</a>');
 document.write('    <a href="api/org/slf4j/simple/SimpleLogger.html">Simple</a>');
+document.write('    <p class="menu_header">Other backends</p>');
+document.write('    <a href="https://tinylog.org/v2/download/#slf4j">tinylog</a>');
 document.write('  </p>');
 
 


### PR DESCRIPTION
Found wikipedia mentioned a backend not linked from the slf4j.org site.  Note:  Version 2 is supported.

(and please squash this commit, README.md was created while I did this)