### PR TITLE
Use id instead of (deprecated) name attribute for anchors

### DIFF
--- a/src/site/pages/codes.html
+++ b/src/site/pages/codes.html
@@ -21,7 +21,7 @@
 
     <!-- ====================================================== -->
 
-    <h3 class="doAnchor" name="noProviders">No SLF4J providers
+    <h3 class="doAnchor" id="noProviders">No SLF4J providers
     were found.
     </h3>
 
@@ -58,7 +58,7 @@
     
     <!-- ====================================================== -->    
 
-    <h3 class="doAnchor" name="ignoredBindings">Class path contains
+    <h3 class="doAnchor" id="ignoredBindings">Class path contains
     SLF4J bindings targeting slf4j-api versions 1.7.x or earlier
     </h3>
 
@@ -88,7 +88,7 @@
     <!-- ====================================================== -->
 
     <h3 class="doAnchor"
-    name="unsuccessfulInit">IllegalStateException:
+    id="unsuccessfulInit">IllegalStateException:
     <code>org.slf4j.LoggerFactory</code> in failed state. Original
     exception was thrown EARLIER.
     </h3>
@@ -105,7 +105,7 @@
 
     <!-- ====================================================== -->
 
-    <h3 class="doAnchor" name="release">The method
+    <h3 class="doAnchor" id="release">The method
     <code>o.a.commons.logging.impl.SLF4FLogFactory#release</code> was
     invoked.      
     </h3>
@@ -138,7 +138,7 @@
     
      <!-- ====================================================== -->
 
-    <h3 class="doAnchor" name="unsupported_operation_in_jcl_over_slf4j">Operation
+    <h3 class="doAnchor" id="unsupported_operation_in_jcl_over_slf4j">Operation
     [suchAndSuch] is not supported in jcl-over-slf4j.
     </h3>
 
@@ -161,7 +161,7 @@
     </p>
 
     <!-- ====================================================== -->
-    <h3 class="doAnchor" name="loggerNameMismatch">Detected logger
+    <h3 class="doAnchor" id="loggerNameMismatch">Detected logger
     name mismatch</h3>
 
     <p>Logger name mismatch warnings are printed only if the
@@ -216,7 +216,7 @@ class B extends A {
 
     <!-- ====================================================== -->
 
-    <h3 class="doAnchor" name="StaticLoggerBinder">Failed to load class
+    <h3 class="doAnchor" id="StaticLoggerBinder">Failed to load class
     <code>org.slf4j.impl.StaticLoggerBinder</code></h3>
 
     <p>This warning message is reported when the
@@ -286,7 +286,7 @@ class B extends A {
 -->
 
     <!-- ====================================================== -->
-    <h3 class="doAnchor" name="multiple_bindings">Multiple bindings
+    <h3 class="doAnchor" id="multiple_bindings">Multiple bindings
     were found on the class path
     </h3>
 
@@ -358,7 +358,7 @@ class B extends A {
   
     <!-- ====================================================== -->
 
-    <h3 class="doAnchor" name="version_mismatch">slf4j-api version
+    <h3 class="doAnchor" id="version_mismatch">slf4j-api version
     does not match that of the binding</h3>
 
     <p>An SLF4J binding designates an artifact such as
@@ -392,7 +392,7 @@ class B extends A {
 
     <!-- ====================================================== -->
     
-    <h3 class="doAnchor" name="null_LF">Logging factory implementation
+    <h3 class="doAnchor" id="null_LF">Logging factory implementation
     cannot be null</h3>
 
     <p>This error is reported when the <code>LoggerFactory</code>
@@ -405,7 +405,7 @@ class B extends A {
 
     <!-- ====================================================== -->
 
-    <h3 class="doAnchor" name="log4jDelegationLoop">Detected both
+    <h3 class="doAnchor" id="log4jDelegationLoop">Detected both
     log4j-over-slf4j.jar AND slf4j-reload4j on the class path,
     preempting <code>StackOverflowError</code>.
     </h3>
@@ -458,7 +458,7 @@ class B extends A {
     <!-- ====================================================== -->
 
 
-    <h3 class="doAnchor" name="jclDelegationLoop">Detected both
+    <h3 class="doAnchor" id="jclDelegationLoop">Detected both
     jcl-over-slf4j.jar AND slf4j-jcl.jar on the class path, preempting
     <code>StackOverflowError</code>.
     </h3>
@@ -500,7 +500,7 @@ class B extends A {
     </p>
 
     <!-- ====================================================== -->
-    <h3 class="doAnchor" name="no_tlm">Exception in
+    <h3 class="doAnchor" id="no_tlm">Exception in
     thread "main" java.lang.NoSuchFieldError: tlm</h3>
 
     <pre class="prettyprint source">
@@ -538,7 +538,7 @@ class B extends A {
     
     <!-- ====================================================== -->
 
-    <h3 class="doAnchor" name="no_static_mdc_binder">Failed to load
+    <h3 class="doAnchor" id="no_static_mdc_binder">Failed to load
     class "org.slf4j.impl.StaticMDCBinder"</h3>
     
     <p>This error indicates that appropriate SLF4J binding could not
@@ -551,7 +551,7 @@ class B extends A {
 
     <!-- ====================================================== -->
 
-    <h3 class="doAnchor" name="null_MDCA">MDCAdapter cannot be null 
+    <h3 class="doAnchor" id="null_MDCA">MDCAdapter cannot be null 
     </h3>
 
     <p>This error is reported when <code>org.slf4j.MDC</code> class
@@ -563,7 +563,7 @@ class B extends A {
     
    <!-- ====================================================== -->
 
-    <h3 class="doAnchor" name="replay">A number (N) of logging calls
+    <h3 class="doAnchor" id="replay">A number (N) of logging calls
     during the initialization phase have been intercepted and are now
     being replayed. These are subject to the filtering rules of the
     underlying logging system.
@@ -583,7 +583,7 @@ class B extends A {
  
     <!-- ====================================================== -->
 
-    <h3 class="doAnchor" name="substituteLogger" >Substitute loggers
+    <h3 class="doAnchor" id="substituteLogger" >Substitute loggers
     were created during the default configuration phase of the
     underlying logging system</h3>
 
@@ -616,7 +616,7 @@ class B extends A {
   
     <!-- ====================================================== -->
 
-    <h3 class="doAnchor" name="log4j_version">SLF4J versions 1.4.0 and
+    <h3 class="doAnchor" id="log4j_version">SLF4J versions 1.4.0 and
     later requires log4j 1.2.12 or later</h3>
 
     <p>The trace level was added to log4j in version 1.2.12 released
@@ -636,7 +636,7 @@ class B extends A {
     <!-- ====================================================== -->
 
      <h3 class="doAnchor"
-     name="log4j_version">java.lang.NoClassDefFoundError:
+     id="log4j_version">java.lang.NoClassDefFoundError:
      org/slf4j/event/LoggingEvent</h3>
 
      <p>Logback-classic version 1.1.4 and later require slf4j-api

--- a/src/site/pages/extensions.html
+++ b/src/site/pages/extensions.html
@@ -26,7 +26,7 @@
 
     </ul>
 
-		<h2><a name="profiler"></a>Profilers</h2>
+		<h2 id="profiler">Profilers</h2>
 
 		<h3>What is a profiler?</h3>
     
@@ -295,7 +295,7 @@
 
 <!-- .............................................................. -->
 
-   <h2><a name="mdcStrLookup"></a>MDCStrLookup</h2>
+   <h2 id="mdcStrLookup">DCStrLookup</h2>
 
    <p>StrLookup is a class defined in Apache Commons Lang. It is used
    in conjunction with the StrSubstitutor class to allow Strings to
@@ -320,7 +320,7 @@
 
 <!-- .............................................................. -->
 
-   <h2><a name="extended_logger"></a>Extended Logger</h2>
+   <h2 id="extended_logger">Extended Logger</h2>
 
    <p>The <a
    href="apidocs/org/slf4j/ext/XLogger.html"><code>XLogger</code></a>

--- a/src/site/pages/faq.html
+++ b/src/site/pages/faq.html
@@ -16,7 +16,7 @@
  <div id="content">
   <script type="text/javascript" src="templates/sponsoredBy.js" ></script>
 
-  <h2><a name="top">Frequently Asked Questions about SLF4J</a></h2>
+  <h2 id="top">Frequently Asked Questions about SLF4J</h2>
 
   <p><b>Generalities</b></p>
   
@@ -190,7 +190,7 @@
   <h2>Generalities</h2>
   
   <dl>
-    <dt class="doAnchor separator" name="what_is">What is SLF4J?</dt>
+    <dt class="doAnchor separator" id="what_is">What is SLF4J?</dt>
     <dd>
       <p>SLF4J is a simple facade for logging systems allowing the
       end-user to plug in the desired logging system at deployment
@@ -198,7 +198,7 @@
       </p>      
     </dd>
     
-    <dt class="doAnchor separator" name="when">When should SLF4J be used?</dt>
+    <dt class="doAnchor separator" id="when">When should SLF4J be used?</dt>
     
     <dd>
       <p>In short, libraries and other embedded components should
@@ -243,7 +243,7 @@
       
     </dd>
     
-    <dt class="doAnchor separator" name="yet_another_facade">Is SLF4J yet
+    <dt class="doAnchor separator" id="yet_another_facade">Is SLF4J yet
     another logging facade?</dt>
     
     <dd>
@@ -257,7 +257,7 @@
       
       
     </dd>
-    <dt class="doAnchor separator" name="why_new_project">If SLF4J fixes JCL,
+    <dt class="doAnchor separator" id="why_new_project">If SLF4J fixes JCL,
     then why wasn't the fix made in JCL instead of creating a new
     project?
     </dt>
@@ -288,7 +288,7 @@
       
     </dd>
     
-    <dt class="doAnchor separator" name="need_to_recompile">When using SLF4J, do
+    <dt class="doAnchor separator" id="need_to_recompile">When using SLF4J, do
     I have to recompile my application to switch to a different
     logging system?
     </dt>
@@ -312,7 +312,7 @@
       
     </dd>
 
-    <dt class="doAnchor separator" name="requirements">What are SLF4J's
+    <dt class="doAnchor separator" id="requirements">What are SLF4J's
     requirements?
     </dt>
     
@@ -360,7 +360,7 @@
     </dd>
 
     <!-- ==================================================== -->
-    <dt class="doAnchor separator" name="changesInVersion200">
+    <dt class="doAnchor separator" id="changesInVersion200">
       What has changed in SLF4J version 2.0.0?
     </dt>
 
@@ -446,7 +446,7 @@
     <!-- ==================================================== -->
     <!-- entry has order dependees -->
 
-    <dt class="doAnchor separator" name="compatibility">Are SLF4J versions
+    <dt class="doAnchor separator" id="compatibility">Are SLF4J versions
     backward compatible?
     </dt>
 
@@ -483,7 +483,7 @@
 
     <!-- ==================================================== -->
 
-    <dt class="doAnchor separator" name="IllegalAccessError">I am getting
+    <dt class="doAnchor separator" id="IllegalAccessError">I am getting
     <code>IllegalAccessError</code> exceptions when using SLF4J. Why
     is that?
     </dt>
@@ -535,7 +535,7 @@ org.slf4j.impl.StaticLoggerBinder.SINGLETON from class org.slf4j.LoggerFactory
 
     <!-- ==================================================== -->
 
-    <dt class="doAnchor separator" name="license">Why is SLF4J licensed under
+    <dt class="doAnchor separator" id="license">Why is SLF4J licensed under
     X11 type license instead of the Apache Software License?
     </dt>
     
@@ -553,7 +553,7 @@ org.slf4j.impl.StaticLoggerBinder.SINGLETON from class org.slf4j.LoggerFactory
     </dd>
 
     <!-- ==================================================== -->
-    <dt class="doAnchor separator" name="where_is_binding">Where can I get a
+    <dt class="doAnchor separator" id="where_is_binding">Where can I get a
     particular SLF4J provider/binding?
     </dt>
     
@@ -581,7 +581,7 @@ org.slf4j.impl.StaticLoggerBinder.SINGLETON from class org.slf4j.LoggerFactory
       
     </dd>
     
-    <dt class="doAnchor separator" name="configure_logging">Should my library
+    <dt class="doAnchor separator" id="configure_logging">Should my library
     attempt to configure logging?
     </dt>
     
@@ -602,7 +602,7 @@ org.slf4j.impl.StaticLoggerBinder.SINGLETON from class org.slf4j.LoggerFactory
     
     <!-- ======================================================= -->
 
-    <dt class="doAnchor separator" name="optional_dependency">In order to reduce
+    <dt class="doAnchor separator" id="optional_dependency">In order to reduce
     the number of dependencies of our software we would like to make
     SLF4J an optional dependency. Is that a good idea?      
     </dt>
@@ -696,7 +696,7 @@ org.slf4j.impl.StaticLoggerBinder.SINGLETON from class org.slf4j.LoggerFactory
 
    <!-- ======================================================= -->
 
-    <dt class="doAnchor separator" name="maven2">What about Maven transitive
+    <dt class="doAnchor separator" id="maven2">What about Maven transitive
     dependencies?
     </dt>
     
@@ -743,7 +743,7 @@ org.slf4j.impl.StaticLoggerBinder.SINGLETON from class org.slf4j.LoggerFactory
     </dd>
     
     <!-- ====================================================== -->
-    <dt class="doAnchor separator" name="excludingJCL">How do I exclude
+    <dt class="doAnchor separator" id="excludingJCL">How do I exclude
     commons-logging as a Maven dependency?
     </dt>
     
@@ -870,7 +870,7 @@ org.slf4j.impl.StaticLoggerBinder.SINGLETON from class org.slf4j.LoggerFactory
 
     </dd>
     
-    <dt class="doAnchor separator" name="jmpsModuleNames">What are the JPMS
+    <dt class="doAnchor separator" id="jmpsModuleNames">What are the JPMS
     module names of the various SLF4J artifacts?
     </dt>
     
@@ -926,7 +926,7 @@ org.slf4j.impl.StaticLoggerBinder.SINGLETON from class org.slf4j.LoggerFactory
   
   <dl>
     
-    <dt class="doAnchor separator" name="string_or_object">Why don't the
+    <dt class="doAnchor separator" id="string_or_object">Why don't the
     printing methods in the Logger interface accept message of type
     Object, but only messages of type String?
     </dt>
@@ -983,7 +983,7 @@ debug(String msg, Throwable t);</pre>
     
     <!-- ====================================================== -->
 
-    <dt class="doAnchor separator" name="exception_message">Can I log an
+    <dt class="doAnchor separator" id="exception_message">Can I log an
     exception without an accompanying message?
     </dt>
 
@@ -1041,7 +1041,7 @@ debug(String msg, Throwable t);</pre>
     <!-- ====================================================== -->
     
     
-    <dt class="doAnchor separator" name="logging_performance">What is the
+    <dt class="doAnchor separator" id="logging_performance">What is the
     fastest way of (not) logging?
     </dt>
 
@@ -1188,7 +1188,7 @@ logger.debug("The new entry is {}.", entry);</pre>
     
     <!-- ================================================= -->
     
-    <dt class="doAnchor separator" name="string_contents">How can I log the
+    <dt class="doAnchor separator" id="string_contents">How can I log the
     string contents of a single (possibly complex) object?</dt>
     
     <dd>
@@ -1218,7 +1218,7 @@ logger.debug("The new entry is {}.", entry);</pre>
     <!-- ================================================= -->
     
     
-    <dt class="doAnchor separator" name="fatal">Why doesn't the
+    <dt class="doAnchor separator" id="fatal">Why doesn't the
     <code>org.slf4j.Logger</code> interface have methods for the FATAL
     level?
     </dt>
@@ -1280,7 +1280,7 @@ class Bar {
     </dd>
     
     <!-- ======================================================= -->
-    <dt class="doAnchor separator" name="trace">Why was the TRACE level
+    <dt class="doAnchor separator" id="trace">Why was the TRACE level
     introduced only in SLF4J version 1.4.0?</dt>
     
     <dd>
@@ -1325,7 +1325,7 @@ class Bar {
     </dd>
 
     <!-- ================================================= -->
-    <dt class="doAnchor separator" name="i18n">Does the SLF4J logging API
+    <dt class="doAnchor separator" id="i18n">Does the SLF4J logging API
     support I18N (internationalization)?
     </dt>
     
@@ -1341,7 +1341,7 @@ class Bar {
 
     <!-- ================================================= -->
 
-    <dt class="doAnchor separator" name="noLoggerFactory">Is it possible to
+    <dt class="doAnchor separator" id="noLoggerFactory">Is it possible to
     retrieve loggers without going through the static methods in
     <code>LoggerFactory</code>?
     </dt>
@@ -1374,7 +1374,7 @@ class Bar {
     
     <!-- ================================================= -->
 
-    <dt class="doAnchor separator" name="paramException">In the presence of an
+    <dt class="doAnchor separator" id="paramException">In the presence of an
     exception/throwable, is it possible to parameterize a logging
     statement?</dt>
 
@@ -1422,7 +1422,7 @@ try {
 
     <!-- ============================================================= -->
 
-    <dt class="doAnchor separator" name="slf4j_compatible">How do I make my
+    <dt class="doAnchor separator" id="slf4j_compatible">How do I make my
     logging framework SLF4J compatible?
     </dt>
     
@@ -1483,7 +1483,7 @@ try {
 
     <!-- ============================================================= -->
 
-    <dt class="doAnchor separator" name="marker_interface">How can my logging
+    <dt class="doAnchor separator" id="marker_interface">How can my logging
     system add support for the <code>Marker</code> interface?
     </dt>
     <dd>
@@ -1517,7 +1517,7 @@ try {
     
     <!-- ============================================================= -->
 
-    <dt class="doAnchor separator" name="version_checks">How does SLF4J's
+    <dt class="doAnchor separator" id="version_checks">How does SLF4J's
     version check mechanism work?
     </dt>
     
@@ -1574,7 +1574,7 @@ try {
   <dl>
 
     <!-- ============================================================= -->
-    <dt class="doAnchor separator" name="declared_static">Should Logger members
+    <dt class="doAnchor separator" id="declared_static">Should Logger members
     of a class be declared as static?
     </dt>
     <dd>
@@ -1739,7 +1739,7 @@ try {
   
   <!-- ============================================================= -->
   <dl>
-    <dt class="doAnchor separator" name="declaration_pattern">Is there a
+    <dt class="doAnchor separator" id="declaration_pattern">Is there a
     recommended idiom for declaring a logger in a class?
     </dt>
     

--- a/src/site/pages/js/decorator.js
+++ b/src/site/pages/js/decorator.js
@@ -34,7 +34,7 @@ function decoratePropertiesInTables(anchor) {
 
    var tmpHTML = p.innerHTML;
    var propName = e.innerHTML;
-   var nameAttr = $(e).attr('name')
+   var nameAttr = $(e).attr('id')
     
    if(nameAttr == null) {
      var containerAttr = $(e).attr('container')
@@ -44,7 +44,7 @@ function decoratePropertiesInTables(anchor) {
        nameAttr = propName;
    }
    
-   p.innerHTML = "<a name='" + nameAttr + "' href='#" + nameAttr +
+   p.innerHTML = "<a href='#" + nameAttr +
                 "'><span class='anchor'/></a><b>" +tmpHTML +"</b>";
    scrollIfMatch(p, nameAttr, anchor);
  } // for 
@@ -55,10 +55,10 @@ function decorateConversionWordInTables(anchor) {
  for(var i = 0; i < elems.length; i++) {
    var e = elems[i];
    var tmpHTML = e.innerHTML;
-   var nameAttr = $(e).attr('name')
+   var nameAttr = $(e).attr('id')
    if(nameAttr == null) 
      continue;
-   e.innerHTML = "<a name='" + nameAttr + "' href='#" + nameAttr +
+   e.innerHTML = "<a href='#" + nameAttr +
                 "'><span class='anchor'/></a>" +tmpHTML;
    scrollIfMatch(e, nameAttr, anchor);
  }
@@ -70,11 +70,11 @@ function decorateDoAnchor(anchor) {
    for(var i = 0; i < elems.length; i++) {
      var e = elems[i];
      var tmpHTML = e.innerHTML;
-     var nameAttr = $(e).attr('name')
+     var nameAttr = $(e).attr('id')
      if(nameAttr == null) {
        nameAttr = camelCase($.trim(tmpHTML))
      }
-     e.innerHTML = "<a name='" + nameAttr + "' href='#" + nameAttr +
+     e.innerHTML = "<a href='#" + nameAttr +
                 "'><span class='anchor'/></a>" +tmpHTML;
      scrollIfMatch(e, nameAttr, anchor);
    }

--- a/src/site/pages/legacy.html
+++ b/src/site/pages/legacy.html
@@ -44,10 +44,10 @@
     <p>
     </p>
     
-    <h2 class="doAnchor" name="jcl-over-slf4j">Gradual migration to
+    <h2 class="doAnchor" id="jcl-over-slf4j">Gradual migration to
     SLF4J from Jakarta Commons Logging (JCL)</h2>
     
-    <h4 class="doAnchor" name="jclOverSLF4J"><em>jcl-over-slf4j.jar</em></h4>
+    <h4 class="doAnchor" id="jclOverSLF4J"><em>jcl-over-slf4j.jar</em></h4>
     
     <p>To ease migration to SLF4J from JCL, SLF4J distributions
     include the jar file <em>jcl-over-slf4j.jar</em>. This jar file is
@@ -72,7 +72,7 @@
     class loader issues related to commons logging.
     </p>
     
-    <h3  class="doAnchor" name="slf4jJCL"><em>slf4j-jcl.jar</em></h3>
+    <h3  class="doAnchor" id="slf4jJCL"><em>slf4j-jcl.jar</em></h3>
     
     <p>Some of our users after having switched to SLF4J API realize that
     in some contexts the use of JCL is mandatory and their use of SLF4J
@@ -87,7 +87,7 @@
     </p>
     
     <h3 class="doAnchor"
-    name="jclRecursion"><em>jcl-over-slf4j.jar</em> should not be
+    id="jclRecursion"><em>jcl-over-slf4j.jar</em> should not be
     confused with <em>slf4j-jcl.jar</em></h3>
     
     
@@ -117,7 +117,7 @@
     </p>
     
     
-    <h2 class="doAnchor" name="log4j-over-slf4j">log4j-over-slf4j</h2>
+    <h2 class="doAnchor" id="log4j-over-slf4j">log4j-over-slf4j</h2>
     
     <p>SLF4J ship with a module called <em>log4j-over-slf4j</em>.  It
     allows log4j users to migrate existing applications to SLF4J without
@@ -126,7 +126,7 @@
     described below.
     </p>
     
-    <h4 class="doAnchor" name="losHow">How does it work?</h4>
+    <h4 class="doAnchor" id="losHow">How does it work?</h4>
     
     <p>The log4j-over-slf4j module contains replacements of most widely
     used log4j classes, namely <code>org.apache.log4j.Category</code>,
@@ -156,7 +156,7 @@
     href="http://logback.qos.ch/manual/index.html">its manual</a>.
     </p>
     
-    <h4 class="doAnchor" name="losFail">When does it not work?</h4>
+    <h4 class="doAnchor" id="losFail">When does it not work?</h4>
     
     <p>The <em>log4j-over-slf4j</em> module will not work when the
     application calls log4j components that are not present in the
@@ -170,7 +170,7 @@
 
     
     
-    <h4 class="doAnchor" name="losOverhead">What about the
+    <h4 class="doAnchor" id="losOverhead">What about the
     overhead?</h4>
     
     <p>The overhead of using log4j-over-slf4j instead of log4j
@@ -187,7 +187,7 @@
     </p>
 
     <!--
-    <h4 class="doAnchor" name="log4jRecursion">log4j-over-slf4j.jar
+    <h4 class="doAnchor" id="log4jRecursion">log4j-over-slf4j.jar
     and slf4j-log4j12.jar cannot be present simultaneously
     </h4>
     
@@ -201,7 +201,7 @@
     </p>
     -->
     
-    <h4 class="doAnchor" name="log4jRecursion2">log4j-over-slf4j.jar
+    <h4 class="doAnchor" id="log4jRecursion2">log4j-over-slf4j.jar
     and slf4j-reload4j.jar cannot be present simultaneously
     </h4>
     
@@ -217,7 +217,7 @@
     </p>
 
     
-    <h2 class="doAnchor" name="jul-to-slf4j">jul-to-slf4j bridge</h2>
+    <h2 class="doAnchor" id="jul-to-slf4j">jul-to-slf4j bridge</h2>
     
     <p>The <em>jul-to-slf4j.jar</em> artifact includes a
     java.util.logging (jul) handler, namely
@@ -257,7 +257,7 @@
     </ol>
     
     
-    <h4 class="doAnchor" name="julRecursion">jul-to-slf4j.jar and slf4j-jdk14.jar cannot be present
+    <h4 class="doAnchor" id="julRecursion">jul-to-slf4j.jar and slf4j-jdk14.jar cannot be present
     simultaneously
     </h4>
     

--- a/src/site/pages/log4shell.html
+++ b/src/site/pages/log4shell.html
@@ -184,7 +184,7 @@
       LOGBACK-1591/CVE-2021-42550 are of different severity
       levels.</span></p>
 
-      <h3 class="doAnchor" name="concreteMeasures">Additional protective
+      <h3 class="doAnchor" id="concreteMeasures">Additional protective
       measure: write protect log4j{1,2}/logback configuration
       files</h3>
 

--- a/src/site/pages/manual.html
+++ b/src/site/pages/manual.html
@@ -26,13 +26,13 @@
     the addition of only a single mandatory dependency, namely
     <em>slf4j-api-${latest.stable.version}.jar</em>.</p>
 
-    <h3 class="doAnchor" name="where_coordinates">Where are the Maven coordinates?</h3>
+    <h3 class="doAnchor" id="where_coordinates">Where are the Maven coordinates?</h3>
 
     <p>At this time if you are only interested in obtaining the
     coordinates for using SLF4J API with a logging backend, you can <a
     href="#projectDep">jump to the relevant section</a>.</p>
 
-    <h3 class="doAnchor" name="salient_changes">Salient historical changes</h3>
+    <h3 class="doAnchor" id="salient_changes">Salient historical changes</h3>
     
     <p><span class="label">since 1.6.0</span> If no binding is found on the
     class path, then SLF4J will default to a no-operation
@@ -79,7 +79,7 @@
     details.
     </p>
 
-    <h3 class="doAnchor" name="hello_world">Hello World</h3>
+    <h3 class="doAnchor" id="hello_world">Hello World</h3>
 
     <p>As customary in programming tradition, here is an example
     illustrating the simplest way to output "Hello world" using SLF4J.
@@ -135,7 +135,7 @@ SLF4J: See https://www.slf4j.org/codes.html#StaticLoggerBinder for further detai
 
      <pre class="output">0 [main] INFO HelloWorld - Hello World</pre>
       
-     <h3 class="doAnchor" name="typical_usage">Typical usage
+     <h3 class="doAnchor" id="typical_usage">Typical usage
      pattern</h3>
  
      <p>The sample code below illustrates the typical usage pattern
@@ -169,7 +169,7 @@ SLF4J: See https://www.slf4j.org/codes.html#StaticLoggerBinder for further detai
 21: } </code></pre>
       
 
-      <h3 class="doAnchor" name="fluent">Fluent Logging API</h3>
+      <h3 class="doAnchor" id="fluent">Fluent Logging API</h3>
 
       <p><span class="label">since 2.0.0</span> SLF4J API version
       2.0.0 requires Java 8 and introduces a backward-compatible
@@ -262,7 +262,7 @@ logger.atDebug().setMessge("Temperature changed.").<b>addKeyValue("oldT", oldT)<
       customizable behaviour.</p>
 
       
-      <h3 class="doAnchor" name="swapping">Binding with a logging
+      <h3 class="doAnchor" id="swapping">Binding with a logging
       framework at deployment time</h3>
 
       <p>As mentioned previously, SLF4J supports various logging
@@ -401,7 +401,7 @@ logger.atDebug().setMessge("Temperature changed.").<b>addKeyValue("oldT", oldT)<
       find it very easy to write SLF4J bindings.
       </p>
      
-      <h3 class="doAnchor" name="libraries">Libraries</h3>
+      <h3 class="doAnchor" id="libraries">Libraries</h3>
 
       <p>Authors of widely-distributed components and libraries may
       code against the SLF4J interface in order to avoid imposing a
@@ -447,7 +447,7 @@ logger.atDebug().setMessge("Temperature changed.").<b>addKeyValue("oldT", oldT)<
       href="faq.html#optional_dependency">dependency reduction</a> and
       <a href="faq.html#optional_dependency">testing</a>.</p>
 
-      <h3 class="doAnchor" name="projectDep">Declaring project
+      <h3 class="doAnchor" id="projectDep">Declaring project
       dependencies for logging</h3>
 
       <p>Given Maven's transitive dependency rules, for "regular"
@@ -616,7 +616,7 @@ logger.atDebug().setMessge("Temperature changed.").<b>addKeyValue("oldT", oldT)<
 
   <!-- =========================================================== -->
    
-      <h3 class="doAnchor" name="compatibility">Binary
+      <h3 class="doAnchor" id="compatibility">Binary
       compatibility</h3>
 
       <p>An SLF4J binding designates an artifact such as
@@ -658,7 +658,7 @@ logger.atDebug().setMessge("Temperature changed.").<b>addKeyValue("oldT", oldT)<
       a warning about the suspected mismatch.
       </p>
 
-      <h3 class="doAnchor" name="consolidate">Consolidate logging via
+      <h3 class="doAnchor" id="consolidate">Consolidate logging via
       SLF4J</h3>
 
       <p>Often times, a given project will depend on various
@@ -672,7 +672,7 @@ logger.atDebug().setMessge("Temperature changed.").<b>addKeyValue("oldT", oldT)<
       APIs</b></a>.
       </p>
 
-      <h3 class="doAnchor" name="jep264">Support for JDK Platform Logging (JEP 264)
+      <h3 class="doAnchor" id="jep264">Support for JDK Platform Logging (JEP 264)
       SLF4J</h3>
 
       <p><span class="label notice">Since 2.0.0-alpha5</span> The
@@ -688,7 +688,7 @@ logger.atDebug().setMessge("Temperature changed.").<b>addKeyValue("oldT", oldT)<
 
 
       
-      <h3 class="doAnchor" name="mdc">Mapped Diagnostic Context (MDC) support</h3>
+      <h3 class="doAnchor" id="mdc">Mapped Diagnostic Context (MDC) support</h3>
 
       <p>"Mapped Diagnostic Context" is essentially a map maintained
       by the logging framework where the application code provides
@@ -718,7 +718,7 @@ logger.atDebug().setMessge("Temperature changed.").<b>addKeyValue("oldT", oldT)<
 
     
       
-      <h3 class="doAnchor" name="summary">Executive summary</h3>
+      <h3 class="doAnchor" id="summary">Executive summary</h3>
 
       <div clas="bodyTable">
       <table  class="bodyTable striped" cellspacing="4" cellpadding="4">

--- a/src/site/pages/news.html
+++ b/src/site/pages/news.html
@@ -73,7 +73,7 @@
    
    <hr noshade="noshade" size="1"/>
    
-   <h3 class="doAnchor" name="2.0.7">2023-03-17 - Release of SLF4J 2.0.7</h3>
+   <h3 class="doAnchor" id="2.0.7">2023-03-17 - Release of SLF4J 2.0.7</h3>
 
    <p>&bull; Fixed several OSGi MANIFEST.MF related issues, namely 
      <a href="https://jira.qos.ch/browse/SLF4J-581">SLF4J-581</a>,
@@ -101,7 +101,7 @@
    
    <hr noshade="noshade" size="1"/>
    
-   <h3 class="doAnchor" name="2.0.6">2022-12-12 - Release of SLF4J 2.0.6</h3>
+   <h3 class="doAnchor" id="2.0.6">2022-12-12 - Release of SLF4J 2.0.6</h3>
 
 
    <p>&bull; When replaying events occuring during initialization, the
@@ -126,7 +126,7 @@
    
    <hr noshade="noshade" size="1"/>
    
-   <h3 class="doAnchor" name="2.0.5">2022-11-25 - Release of SLF4J 2.0.5</h3>
+   <h3 class="doAnchor" id="2.0.5">2022-11-25 - Release of SLF4J 2.0.5</h3>
 
    <p>&bull; If a <code>SecurityManager</code> is installed, then
    <code>LoggerFactory</code> will now load providers as a privileged
@@ -144,7 +144,7 @@
        
    <hr noshade="noshade" size="1"/>
    
-   <h3 class="doAnchor" name="2.0.4">2022-11-17 - Release of SLF4J 2.0.4</h3>
+   <h3 class="doAnchor" id="2.0.4">2022-11-17 - Release of SLF4J 2.0.4</h3>
 
    <p>&bull; <code>LoggerFactory</code> now uses the class loader that
    loaded <code>LoggerFactory</code> class itself to find providers of
@@ -172,7 +172,7 @@
    
    <hr noshade="noshade" size="1"/>
    
-   <h3 class="doAnchor" name="2.0.3">2022-09-28 - Release of SLF4J 2.0.3</h3>
+   <h3 class="doAnchor" id="2.0.3">2022-09-28 - Release of SLF4J 2.0.3</h3>
 
    <p>&bull; Fixed a bug in <code>Reload4jLoggerAdapter</code> when
    used in conjunction with the fluent API, the timestamp would not be
@@ -188,7 +188,7 @@
    
    <hr noshade="noshade" size="1"/>
    
-   <h3 class="doAnchor" name="2.0.2">2022-09-20 - Release of SLF4J 2.0.2</h3>
+   <h3 class="doAnchor" id="2.0.2">2022-09-20 - Release of SLF4J 2.0.2</h3>
 
    <p>&bull; Fixed bug in the <code>setContextMap()</code> method
    of <code>Reload4jMDCAdapter</code>.  This issue was reported
@@ -203,7 +203,7 @@
    
    <hr noshade="noshade" size="1"/>
    
-   <h3 class="doAnchor" name="2.0.1">2022-09-14 - Release of SLF4J 2.0.1</h3>
+   <h3 class="doAnchor" id="2.0.1">2022-09-14 - Release of SLF4J 2.0.1</h3>
 
    <p>&bull; The <code>Logger.makeLoggingEventBuilder</code> method
    semantics has changed so that overriding implementations should now
@@ -225,7 +225,7 @@
    
    <hr noshade="noshade" size="1"/>
    
-   <h3 class="doAnchor" name="2.0.0">2022-08-20 - Release of SLF4J 2.0.0</h3>
+   <h3 class="doAnchor" id="2.0.0">2022-08-20 - Release of SLF4J 2.0.0</h3>
 
    
    <p>&bull; Except minor javadoc changes, this release is identical to
@@ -239,7 +239,7 @@
    
    <hr noshade="noshade" size="1"/>
    
-   <h3 class="doAnchor" name="2.0.0-beta1">2022-08-06 - Release of SLF4J 2.0.0-beta1</h3>
+   <h3 class="doAnchor" id="2.0.0-beta1">2022-08-06 - Release of SLF4J 2.0.0-beta1</h3>
 
    <p>&bull; Methods in the <code>LoggingEventBuilder</code> interface
    returning an instance of <code>LoggingEventBuilder</code> are now
@@ -267,7 +267,7 @@
    
    <hr noshade="noshade" size="1"/>
    
-   <h3 class="doAnchor" name="2.0.0-beta0">2022-08-05 - Release of SLF4J 2.0.0-beta0</h3>
+   <h3 class="doAnchor" id="2.0.0-beta0">2022-08-05 - Release of SLF4J 2.0.0-beta0</h3>
 
    <p>&bull; After
    a <a href="https://github.com/qos-ch/slf4j/discussions/280">long
@@ -284,7 +284,7 @@
    
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="2.0.0-alpha7">2022-03-17 - Release of SLF4J 2.0.0-alpha7</h3>
+   <h3 class="doAnchor" id="2.0.0-alpha7">2022-03-17 - Release of SLF4J 2.0.0-alpha7</h3>
 
    <p>&bull; Mirroring the change in the 1.7.x series, in this release
    also the "slf4j-log4j12" artifact automatically instructs Maven to
@@ -323,7 +323,7 @@
 
    
    
-   <h3 class="doAnchor" name="1.7.36">2022-02-08 - Release of SLF4J 1.7.36</h3>
+   <h3 class="doAnchor" id="1.7.36">2022-02-08 - Release of SLF4J 1.7.36</h3>
 
    <p>Correct corrupt "Export-Package" declaration in
    <em>MANIFEST.MF</em> in <em>log4j-over-slf4j</em> module. This
@@ -340,7 +340,7 @@
    
    <hr noshade="noshade" size="1"/>
    
-    <h3 class="doAnchor" name="1.7.35">2022-01-25 - Release of SLF4J 1.7.35</h3>
+    <h3 class="doAnchor" id="1.7.35">2022-01-25 - Release of SLF4J 1.7.35</h3>
 
     <p>&bull; In this release, the "slf4j-log4j12" artifact
     automatically instructs Maven to use the "slf4j-reload4j" artifact
@@ -362,13 +362,13 @@
     Alexander Veit.
     </p>
     
-    <h3 class="doAnchor" name="1.7.34">2022-01-25 - Release of SLF4J 1.7.34</h3>
+    <h3 class="doAnchor" id="1.7.34">2022-01-25 - Release of SLF4J 1.7.34</h3>
 
     <p>The relocation element in slf4j-log4j12 had incorrect
     version number. Version 1.7.34 should not be used.
     </p>
     
-   <h3 class="doAnchor" name="2.0.0-alpha6">2022-01-13 - Release of SLF4J 2.0.0-alpha6</h3>
+   <h3 class="doAnchor" id="2.0.0-alpha6">2022-01-13 - Release of SLF4J 2.0.0-alpha6</h3>
 
    <p>&bull; SLF4J now ships with the <em>slf4j-reload4j</em> module
    delegating to the reload4j backend. <a
@@ -383,7 +383,7 @@
 
    <hr noshade="noshade" size="1"/>
    
-   <h3 class="doAnchor" name="1.7.33">2022-01-13 - Release of SLF4J 1.7.33</h3>
+   <h3 class="doAnchor" id="1.7.33">2022-01-13 - Release of SLF4J 1.7.33</h3>
 
    <p>&bull; SLF4J now ships with the <em>slf4j-reload4j</em> module
    delegating to the reload4j backend. <a
@@ -399,7 +399,7 @@
    
    <hr noshade="noshade" size="1"/>
    
-   <h3 class="doAnchor" name="2.0.0-alpha5">30th of August, 2021 - Release of SLF4J 2.0.0-alpha5</h3>
+   <h3 class="doAnchor" id="2.0.0-alpha5">30th of August, 2021 - Release of SLF4J 2.0.0-alpha5</h3>
 
    <p>&bull; The
    <em>META-INF/services/java.lang.System&dollar;LoggerFinder</em>
@@ -411,7 +411,7 @@
    
    <hr noshade="noshade" size="1"/>
    
-   <h3 class="doAnchor" name="2.0.0-alpha4">12th of August, 2021 - Release of SLF4J 2.0.0-alpha4</h3>
+   <h3 class="doAnchor" id="2.0.0-alpha4">12th of August, 2021 - Release of SLF4J 2.0.0-alpha4</h3>
 
    <p>&bull; Added support for the <a
    href="https://openjdk.java.net/jeps/264">Java Platform Logging API
@@ -422,7 +422,7 @@
    
    <hr noshade="noshade" size="1"/>
    
-   <h3 class="doAnchor" name="2.0.0-alpha3">10th of August, 2021 - Release of SLF4J 2.0.0-alpha3</h3>
+   <h3 class="doAnchor" id="2.0.0-alpha3">10th of August, 2021 - Release of SLF4J 2.0.0-alpha3</h3>
   
    <p>In addition to fixes imported from the 1.7 branch, such as <a
    href="https://jira.qos.ch/browse/SLF4J-515">SLF4J-515</a>, this
@@ -452,7 +452,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.32">20th of July, 2021 - Release of SLF4J 1.7.32</h3>
+   <h3 class="doAnchor" id="1.7.32">20th of July, 2021 - Release of SLF4J 1.7.32</h3>
 
    <p>In the slf4j-simple module, <code>SimpleLogger</code> now caters
    for concurrent access. This fixes <a
@@ -462,7 +462,7 @@
    
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="2.0.0-alpha2">2nd of July, 2021 - Release of SLF4J 2.0.0-alpha2</h3>
+   <h3 class="doAnchor" id="2.0.0-alpha2">2nd of July, 2021 - Release of SLF4J 2.0.0-alpha2</h3>
         
    <p>&bull; Fixed important bug in the fluent API. The
    <code>LoggingEventBuilder.addArgument(Supplier)</code> method now
@@ -505,7 +505,7 @@
    
    
    
-   <h3 class="doAnchor" name="1.7.31">18th of June, 2021 - Release of SLF4J 1.7.31</h3>
+   <h3 class="doAnchor" id="1.7.31">18th of June, 2021 - Release of SLF4J 1.7.31</h3>
 
    <p>In the jcl-over-slf4j module avoid <code>Object</code> to
    <code>String</code> conversion. This issue was reported in <a
@@ -520,7 +520,7 @@
    
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.30">16th of December, 2019 - Release of SLF4J 1.7.30</h3>
+   <h3 class="doAnchor" id="1.7.30">16th of December, 2019 - Release of SLF4J 1.7.30</h3>
 
    <p>Fixed a memory leak in case of no provided binding and
    multithreaded initialization as described in <a
@@ -529,7 +529,7 @@
    
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.29">31st of October, 2019 - Release of SLF4J 1.7.29</h3>
+   <h3 class="doAnchor" id="1.7.29">31st of October, 2019 - Release of SLF4J 1.7.29</h3>
 
    <p>In the pom file for <em>jcl-over-slf4j</em> module, the Apache
    license is now explicitly mentioned. In previous versions, the
@@ -538,7 +538,7 @@
    
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="2.0.0-alpha1">October 1st, 2019  - Release of SLF4J 2.0.0-alpha1</h3>
+   <h3 class="doAnchor" id="2.0.0-alpha1">October 1st, 2019  - Release of SLF4J 2.0.0-alpha1</h3>
   
    <p>&bull; Refactored the fluent-api in
    <code>org.slf4j.Logger</code> interface to ease the work required
@@ -564,7 +564,7 @@
    
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.28">10th of August, 2019 - Release of SLF4J 1.7.28</h3>
+   <h3 class="doAnchor" id="1.7.28">10th of August, 2019 - Release of SLF4J 1.7.28</h3>
 
    <p>&bull; Added <code>Automatic-Module-Name</code> in
    <em>MANIFEST.MF</em> files in various SLF4J artifacts. This fixes
@@ -614,7 +614,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.27">6th of August, 2019 - Release of SLF4J 1.7.27</h3>
+   <h3 class="doAnchor" id="1.7.27">6th of August, 2019 - Release of SLF4J 1.7.27</h3>
 
 
    <p>This version had the incorrect "Automatic-Module-Name" for the
@@ -624,7 +624,7 @@
    
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="2.0.0-alpha0">13th of June, 2019  - Release of SLF4J 2.0.0-alpha0</h3>
+   <h3 class="doAnchor" id="2.0.0-alpha0">13th of June, 2019  - Release of SLF4J 2.0.0-alpha0</h3>
 
    <p class="highlight">The the 2.0.x series requires Java&nbsp;8 and
    adds a backward-compatible <a
@@ -641,7 +641,7 @@
    
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.8.0-beta5">2019 - Release of SLF4J 1.8.0-beta5</h3>
+   <h3 class="doAnchor" id="1.8.0-beta5">2019 - Release of SLF4J 1.8.0-beta5</h3>
 
    <p>Fixed ignored Throwable issue in log4j-over-slf4j as reported in
    <a href="https://jira.qos.ch/browse/SLF4J-233">SLF4J-233</a> by
@@ -667,7 +667,7 @@
    
    <hr noshade="noshade" size="1"/>
    
-   <h3 class="doAnchor" name="1.8.0-beta4">February 19th, 2019 - Release of SLF4J 1.8.0-beta4</h3>
+   <h3 class="doAnchor" id="1.8.0-beta4">February 19th, 2019 - Release of SLF4J 1.8.0-beta4</h3>
 
    <p class="highlight">In the 1.8.x series, SLF4J has been
    modularized per <a
@@ -725,7 +725,7 @@
    href="https://jira.qos.ch/browse/SLF4J-454">SLF4J-454</a>.
 
    
-   <h3 class="doAnchor" name="1.7.26">February 16th, 2019 - Release of SLF4J 1.7.26</h3>
+   <h3 class="doAnchor" id="1.7.26">February 16th, 2019 - Release of SLF4J 1.7.26</h3>
 
    <p>Due to popular demand in relation to <a
    href="https://nvd.nist.gov/vuln/detail/CVE-2018-8088">CVE-2018-8088</a>,
@@ -742,7 +742,7 @@
    
    <hr noshade="noshade" size="1"/> 
    
-   <h3 class="doAnchor" name="1.8.0-beta2">21st of March, 2018 - Release of SLF4J 1.8.0-beta2</h3>
+   <h3 class="doAnchor" id="1.8.0-beta2">21st of March, 2018 - Release of SLF4J 1.8.0-beta2</h3>
    
 
    <p>Automatic module name for the artifact <em>jul-to-slf4j.jar</em>
@@ -772,7 +772,7 @@
    and <a href="https://jira.qos.ch/browse/SLF4J-431">SLF4J-431</a>.</p>
   
    
-   <h3 class="doAnchor" name="1.8.0-beta1">January 30th, 2018 - Release of SLF4J 1.8.0-beta1</h3>
+   <h3 class="doAnchor" id="1.8.0-beta1">January 30th, 2018 - Release of SLF4J 1.8.0-beta1</h3>
    
    <p>Fix Travis build issues as reported in <a
    href="https://jira.qos.ch/browse/SLF4J-427">SLF4J-427</a> by 
@@ -793,7 +793,7 @@
    
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.8.0-beta0">October 20th, 2017 - Release of SLF4J 1.8.0-beta0</h3>
+   <h3 class="doAnchor" id="1.8.0-beta0">October 20th, 2017 - Release of SLF4J 1.8.0-beta0</h3>
 
    <p>Given that the same package name in different modules is a
    showstopper in Java 9, the <code>org.slf4j.impl</code> package has
@@ -808,7 +808,7 @@
    
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.8.0-alpha2">April 25th, 2017 - Release of SLF4J 1.8.0-alpha2</h3>
+   <h3 class="doAnchor" id="1.8.0-alpha2">April 25th, 2017 - Release of SLF4J 1.8.0-alpha2</h3>
 
    <p>The JPMS module names for <code>log4j-over-slf4j</code> and
    <code>jcl-over-slf4j</code> are now based on the names of the
@@ -829,7 +829,7 @@
    
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.8.0-alpha1">April 13th, 2017 - Release of SLF4J 1.8.0-alpha1</h3>
+   <h3 class="doAnchor" id="1.8.0-alpha1">April 13th, 2017 - Release of SLF4J 1.8.0-alpha1</h3>
 
    <p>Removed spurious System.out.println in the slf4j-log4j12
    module. See <a
@@ -838,7 +838,7 @@
    
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.8.0-alpha0">April 7th, 2017 - Release of SLF4J 1.8.0-alpha0</h3>
+   <h3 class="doAnchor" id="1.8.0-alpha0">April 7th, 2017 - Release of SLF4J 1.8.0-alpha0</h3>
 
    <p>SLF4J has been modularized per <a
    href="http://openjdk.java.net/projects/jigsaw/spec/">JPMS/Jigsaw</a>
@@ -852,7 +852,7 @@
    
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.25">March 16th, 2017 - Release of SLF4J 1.7.25</h3>
+   <h3 class="doAnchor" id="1.7.25">March 16th, 2017 - Release of SLF4J 1.7.25</h3>
 
    <p>In slf4j-simple module, added a configuration option to
    enable/disable caching of the System.out/err target. This
@@ -873,7 +873,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.24">February 23rd, 2017 - Release of SLF4J 1.7.24</h3>
+   <h3 class="doAnchor" id="1.7.24">February 23rd, 2017 - Release of SLF4J 1.7.24</h3>
 
    <p>In its MANIFEST.MF file, the jcl-over-slf4j module now declares
    exporting <code>org.apache.commons.logging</code> version "1.2"
@@ -897,7 +897,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.23">February 15th, 2017 - Release of SLF4J 1.7.23</h3>
+   <h3 class="doAnchor" id="1.7.23">February 15th, 2017 - Release of SLF4J 1.7.23</h3>
 
    <p class="highlight">Update to SLF4J version 1.7.23 to enable
    slf4j-log4j12 to run under Java 9.</p>
@@ -925,7 +925,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.22">December 13th, 2016 - Release of SLF4J 1.7.22</h3>
+   <h3 class="doAnchor" id="1.7.22">December 13th, 2016 - Release of SLF4J 1.7.22</h3>
 
    <p>Add support for OFF level in <code>SimpleLogger</code>. This
    feature was requested in <a
@@ -941,7 +941,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.21">April 4th, 2016 - Release of SLF4J 1.7.21</h3>
+   <h3 class="doAnchor" id="1.7.21">April 4th, 2016 - Release of SLF4J 1.7.21</h3>
 
    <p>Fixed a memory leak due to a race-condition occurring during
    SLF4J initialization. In that case, some
@@ -959,7 +959,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.20">March 29th, 2016 - Release of SLF4J 1.7.20</h3>
+   <h3 class="doAnchor" id="1.7.20">March 29th, 2016 - Release of SLF4J 1.7.20</h3>
 
    <p class="red">Releases 1.7.19 and 1.7.20 suffer from a <a
    href="http://jira.qos.ch/browse/SLF4J-364">memory leak</a>. Please
@@ -975,7 +975,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.19">March 14th, 2016 - Release of SLF4J 1.7.19</h3>
+   <h3 class="doAnchor" id="1.7.19">March 14th, 2016 - Release of SLF4J 1.7.19</h3>
 
    <p class="red">Releases 1.7.19 and 1.7.20 suffer from a <a
    href="http://jira.qos.ch/browse/SLF4J-364">memory leak</a>. Please
@@ -997,7 +997,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.18">26th of February, 2016 - Release of SLF4J 1.7.18</h3>
+   <h3 class="doAnchor" id="1.7.18">26th of February, 2016 - Release of SLF4J 1.7.18</h3>
 
    <p>Initialization of the slf4j-simple module is now thread safe
    fixing <a href="http://jira.qos.ch/browse/SLF4J-356">SLF4J-356</a>.
@@ -1011,7 +1011,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.17">19th of February, 2016 - Release of SLF4J 1.7.17</h3>
+   <h3 class="doAnchor" id="1.7.17">19th of February, 2016 - Release of SLF4J 1.7.17</h3>
 
    <p>When running under Android, skip binding ambiguity check during
    initialization for better performance. The fix introduced in version 1.7.14
@@ -1020,7 +1020,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.16">11th of February, 2016 - Release of SLF4J 1.7.16</h3>
+   <h3 class="doAnchor" id="1.7.16">11th of February, 2016 - Release of SLF4J 1.7.16</h3>
 
    <p>The <code>MANIFEST.MF</code> file in slf4j-api.jar module was
    missing an export statement for the <em>org.slf4j.event</em>
@@ -1030,7 +1030,7 @@
    
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.15">9th of February, 2016 - Release of SLF4J 1.7.15</h3>
+   <h3 class="doAnchor" id="1.7.15">9th of February, 2016 - Release of SLF4J 1.7.15</h3>
 
    <p>In previous versions of SLF4J, if the application was already
    multithreaded at the time the first SLF4J logger was created, logs
@@ -1043,7 +1043,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.14">24th of January, 2016 - Release of SLF4J 1.7.14</h3>
+   <h3 class="doAnchor" id="1.7.14">24th of January, 2016 - Release of SLF4J 1.7.14</h3>
 
    <p>The assignment of the INITIALIZATION_STATE variable in
    <code>LoggerFactory</code> is now guaranteed to be consistent for
@@ -1095,7 +1095,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.13">10th of November, 2015 - Release of SLF4J 1.7.13</h3>
+   <h3 class="doAnchor" id="1.7.13">10th of November, 2015 - Release of SLF4J 1.7.13</h3>
 
 
    <p>Fixed <code>LoggerFactory</code> initialisation problem in
@@ -1140,7 +1140,7 @@
   
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.12">March 26th, 2015 - Release of SLF4J 1.7.12</h3>
+   <h3 class="doAnchor" id="1.7.12">March 26th, 2015 - Release of SLF4J 1.7.12</h3>
 
    <p>All java files have been reformatted to with the code formatter
    style defined in <i>codeStyle.xml</i>. This style uses 4 spaces for
@@ -1176,7 +1176,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.10">6th of January, 2015 - Release of SLF4J 1.7.10</h3>
+   <h3 class="doAnchor" id="1.7.10">6th of January, 2015 - Release of SLF4J 1.7.10</h3>
 
    <p>The <code>MDC.putCloseable</code> method now explicitly returns
    <code>MDC.MDCloseable</code> instead of the more generic
@@ -1190,7 +1190,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.9">16th of December, 2014 - Release of SLF4J 1.7.9</h3>
+   <h3 class="doAnchor" id="1.7.9">16th of December, 2014 - Release of SLF4J 1.7.9</h3>
 
    <p class="highlight"><a href="codes.html#loggerNameMismatch">Spot
    incorrectly named loggers</a> by setting the
@@ -1226,7 +1226,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.7">4th of April, 2014 - Release of SLF4J 1.7.7 </h3>
+   <h3 class="doAnchor" id="1.7.7">4th of April, 2014 - Release of SLF4J 1.7.7 </h3>
 
    <p>SFL4J API now uses generics. This enhancement was contributed by
    Otavio Garcia. Due to erasure of generics in Java, the changes are
@@ -1240,7 +1240,7 @@
    module.</p>
 
 
-   <h3 class="doAnchor" name="1.7.6">February 5th, 2014 - Release of SLF4J 1.7.6</h3>
+   <h3 class="doAnchor" id="1.7.6">February 5th, 2014 - Release of SLF4J 1.7.6</h3>
 
    <p>Added slf4j-android module to the slf4j distribution. This
    module is contributed by Andrey Korzhevskiy.</p>
@@ -1293,7 +1293,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.5">25th of March, 2013 - Release of SLF4J 1.7.5</h3>
+   <h3 class="doAnchor" id="1.7.5">25th of March, 2013 - Release of SLF4J 1.7.5</h3>
 
    <p class="highlight">Given the significance of these performance
    improvements, users are highly encouraged to migrate to SLF4J
@@ -1313,14 +1313,14 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.4">18th of March, 2013 - Release of SLF4J 1.7.4</h3>
+   <h3 class="doAnchor" id="1.7.4">18th of March, 2013 - Release of SLF4J 1.7.4</h3>
 
    <p>Added a package private <code>reset()</code> method to
    <code>SimpleLoggerFactory</code> for testing purposes.</p>
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.3">15th of March, 2013 - Release of SLF4J 1.7.3</h3>
+   <h3 class="doAnchor" id="1.7.3">15th of March, 2013 - Release of SLF4J 1.7.3</h3>
 
    <p>The jul-to-slf4j bridge now correctly handles cases where the
    message string contains {}-placeholders but has no or zero
@@ -1336,7 +1336,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.2">11th of October, 2012 - Release of SLF4J 1.7.2</h3>
+   <h3 class="doAnchor" id="1.7.2">11th of October, 2012 - Release of SLF4J 1.7.2</h3>
 
    <p>Added osgi-over-slf4j module which serves as an OSGi LogService
    implementation delegating to slf4j. This module is maintained by
@@ -1361,7 +1361,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.1">14th of September, 2012 - Release of SLF4J 1.7.1</h3>
+   <h3 class="doAnchor" id="1.7.1">14th of September, 2012 - Release of SLF4J 1.7.1</h3>
 
    <p><a
    href="apidocs/org/slf4j/impl/SimpleLogger.html"><code>SimpleLogger</code></a>
@@ -1376,7 +1376,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.7.0">6th of September, 2012 - Release of SLF4J 1.7.0</h3>
+   <h3 class="doAnchor" id="1.7.0">6th of September, 2012 - Release of SLF4J 1.7.0</h3>
 
    <p><span class="bold big green">SLF4J now requires JDK 1.5.</span></p>
 
@@ -1397,7 +1397,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.6.6">11th of June, 2012 - Release of SLF4J 1.6.6</h3>
+   <h3 class="doAnchor" id="1.6.6">11th of June, 2012 - Release of SLF4J 1.6.6</h3>
 
    <p>Source repository has been moved to <a
    href="https://github.com/qos-ch/slf4j">https://github.com/qos-ch/slf4j</a>
@@ -1422,7 +1422,7 @@
    reported by Laurent Pellegrino with Piotr Jagielski providing the
    appropriate patch.</p>
 
-   <h3 class="doAnchor" name="1.6.5">4th of June, 2012 - Release of SLF4J 1.6.5</h3>
+   <h3 class="doAnchor" id="1.6.5">4th of June, 2012 - Release of SLF4J 1.6.5</h3>
 
    <p>In the slf4j-log4j12 module, upgraded the log4j dependency to
    version 1.2.17.</p>
@@ -1437,7 +1437,7 @@
    Mikhail Mazursky who also provided the relevant patch.
    </p>
 
-   <h3 class="doAnchor" name="1.6.4">October 31st, 2011 - Release of SLF4J 1.6.4</h3>
+   <h3 class="doAnchor" id="1.6.4">October 31st, 2011 - Release of SLF4J 1.6.4</h3>
 
    <p>Fixed in thread-safety issues in <code>BasicMDCAdapter</code>
    fixing <a href="http://bugzilla.slf4j.org/show_bug.cgi?id=203">bug
@@ -1451,7 +1451,7 @@
    1.5 preventing it from running under JDK 1.4. Interestingly enough,
    this issue has never been reported by the user community.</p>
 
-   <h3 class="doAnchor" name="1.6.3">October 17th, 2011 - Release of SLF4J 1.6.3</h3>
+   <h3 class="doAnchor" id="1.6.3">October 17th, 2011 - Release of SLF4J 1.6.3</h3>
 
    <p><code>LogEvent</code> class in slf4j-ext module now correctly
    passes the event data as a parameter object. This fixes <a
@@ -1470,7 +1470,7 @@
    reported by Anthony Whitford.
    </p>
 
-   <h3 class="doAnchor" name="1.6.2">August 19th, 2011 - Release of SLF4J 1.6.2</h3>
+   <h3 class="doAnchor" id="1.6.2">August 19th, 2011 - Release of SLF4J 1.6.2</h3>
 
    <p>Fixed <a
    href="http://bugzilla.slf4j.org/show_bug.cgi?id=138">bug
@@ -1495,7 +1495,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.6.1">July 5th, 2010 - Release of SLF4J 1.6.1</h3>
+   <h3 class="doAnchor" id="1.6.1">July 5th, 2010 - Release of SLF4J 1.6.1</h3>
 
    <p>Updated log4j dependency to version 1.2.16 and <a
    href="http://cal10n.qos.ch/">CAL10N</a> dependency to version
@@ -1512,7 +1512,7 @@
 
    <hr noshade="noshade" size="1"/>
 
-   <h3 class="doAnchor" name="1.6.0">May 8th, 2010 - Release of SLF4J 1.6.0</h3>
+   <h3 class="doAnchor" id="1.6.0">May 8th, 2010 - Release of SLF4J 1.6.0</h3>
 
    <p>It is expected that <em>all</em> SLF4J releases in the 1.6.x
    series will be mutually compatible.


### PR DESCRIPTION
Also make anchors work without JavaScript. This also allows to directly link to specific parts of a page.